### PR TITLE
README for Project Management Docs: summary & links to all docs in docs/ (closes #2)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,36 @@
+# OctoAcme Project Management Docs — README
+
+This README provides a concise summary of OctoAcme's project management processes and quick navigation to each process document in this folder.
+
+## Project Management Processes Summary
+OctoAcme uses a customer-first and iterative project management methodology. Key principles include clear ownership, regular communication, standardized workflows, proactive risk management, and a continuous improvement culture.
+
+Projects generally follow this lifecycle:
+
+1. **Initiation** — Create a project one-pager, identify stakeholders, and make go/no-go decisions.
+2. **Planning** — Produce a work breakdown, estimate effort, maintain a backlog, record a risk register, and create a release map.
+3. **Execution** — Run iterative work with daily standups, PR-driven development, progress tracking, and regular demos.
+4. **Release & Deployment** — Use CI gating, formal release processes, and rollback plans.
+5. **Retrospective & Continuous Improvement** — Hold regular reviews to collect lessons learned and track action items.
+
+## Documentation Navigation
+- [Project Management Overview](octoacme-project-management-overview.md)
+- [Project Initiation Guide](octoacme-project-initiation.md)
+- [Project Planning](octoacme-project-planning.md)
+- [Execution & Tracking](octoacme-execution-and-tracking.md)
+- [Risks & Communication](octoacme-risks-and-communication.md)
+- [Release & Deployment](octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](octoacme-roles-and-personas.md)
+
+---
+
+**Acceptance checklist**
+
+- [x] Content aligns with existing process docs
+- [x] README improves discoverability and navigation
+- [ ] Proposed content reviewed (if needed)
+
+---
+
+If you'd like edits to the summary tone, length, or additional links (e.g., templates or templates folder), tell me what to add and I’ll update it. 👋


### PR DESCRIPTION
This PR adds a top-level README for the project management docs to improve discoverability and provide a concise summary of OctoAcme's project management processes.

Changes:
- Added docs/README.md containing a short project management summary and links to every process document in the docs/ folder.

Closes #2

Requested reviewer: @GAUR-SHIVAM